### PR TITLE
Long polling notifications

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -208,7 +208,7 @@ function ResponsiveAppBar() {
                         variant="h6"
                         noWrap
                         component="a"
-                        href="/"
+                        onClick={() => navigate('/')}
                         sx={{
                             mr: 2,
                             display: { xs: 'none', md: 'flex' },
@@ -217,6 +217,7 @@ function ResponsiveAppBar() {
                             letterSpacing: '.3rem',
                             color: 'inherit',
                             textDecoration: 'none',
+                            cursor: 'pointer',
                         }}
                     >
                         KEELAPP |
@@ -274,7 +275,6 @@ function ResponsiveAppBar() {
                         variant="h5"
                         noWrap
                         component="a"
-                        href=""
                         onClick={() => navigate('/')}
                         sx={{
                             mr: 2,
@@ -285,6 +285,7 @@ function ResponsiveAppBar() {
                             letterSpacing: '.3rem',
                             color: 'inherit',
                             textDecoration: 'none',
+                            cursor: 'pointer',
 
                             flexGrow: 1,
                         }}

--- a/frontend/src/hooks/useInterval.tsx
+++ b/frontend/src/hooks/useInterval.tsx
@@ -1,0 +1,26 @@
+import {useEffect, useRef} from "react"
+
+export const useIntervalFunction = (callback: () => void, delay: number | null, runCallbackOnStart?: boolean) => {
+
+    const savedCallback = useRef()
+
+    useEffect(() => {
+        // @ts-ignore
+        savedCallback.current = callback
+    }, [callback])
+
+
+    useEffect(() => {
+        function tick() {
+            // @ts-ignore
+            savedCallback.current()
+        }
+        if (delay !== null) {
+            if(runCallbackOnStart!!){
+                tick() // Call the function immediately
+            }
+            const id = setInterval(tick, delay)
+            return () => clearInterval(id)
+        }
+    }, [delay])
+}

--- a/frontend/src/pages/management/MainView.tsx
+++ b/frontend/src/pages/management/MainView.tsx
@@ -10,6 +10,8 @@ import {useDispatch} from "react-redux";
 import AuthVerify from "../../common/AuthVerify";
 import {AppDispatch} from "../../app/store";
 import {toast} from "react-toastify";
+import {useIntervalFunction} from "../../hooks/useInterval";
+import {getNotifications} from "../../features/notifications/notificationSlice";
 
 export function MainView(){
     const componentStyles = {
@@ -47,6 +49,16 @@ export function MainView(){
     const onRenderNotFoundHideHeader = (userExist: boolean) => {
         setDisplayToolbar((userExist))
     }
+
+    useIntervalFunction(
+        () => {
+            if((JSON.parse(localStorage.getItem("user")!))!!){
+                dispatch(getNotifications())
+            }
+        },
+        1000 * 90, // make request every 60 seconds
+        true // make request once before starting countdown
+    )
 
     return(
         <>


### PR DESCRIPTION
Vercel does not support websockets, or server-side events, so we use long-polling to request updated notifications every 90 seconds (configurable). Implemented setInvertalFunction hook to make it work. 